### PR TITLE
Resolve ENS address prior to each contract call where Ether is sent

### DIFF
--- a/src/zaps/EthMaximalist.js
+++ b/src/zaps/EthMaximalist.js
@@ -1,6 +1,6 @@
 const ethers = require('ethers');
 const ethMaxABI = require('../../contracts/abis/EthMaximalist.json')
-const ethMaxAddress = require('../../contracts/addresses/mainnet.json').ETH_MAXIMALIST; //TODO: ENS names need to be resolved when using Metamask
+const ethMaxAddress = require('../../contracts/addresses/ensMainnet.json').ETH_MAXIMALIST;
 
 module.exports = class EthMaximalist {
     constructor(provider, web3) {
@@ -23,9 +23,10 @@ module.exports = class EthMaximalist {
     // Basic sending of Ether to the fallback function of the Eth Maximalist contract
     // !!! Initiates the sending of Ether !!!
     async useEthMaximalistFallback(amount) {
+        const resolvedEnsAddress = await this.currentProvider.resolveName(ethMaxAddress) //ENS name needs to be resolved for use with Metamask
         let valueToInvest = ethers.utils.parseEther(amount)
         let txInfo = {
-            to: ethMaxAddress,
+            to: resolvedEnsAddress,
             value: valueToInvest,
             gasLimit: 5000000,
         }

--- a/src/zaps/Lender.js
+++ b/src/zaps/Lender.js
@@ -1,6 +1,6 @@
 const ethers = require('ethers');
 const lenderABI = require('../../contracts/abis/Lender.json')
-const lenderAddress = require('../../contracts/addresses/mainnet.json').LENDER; //TODO: ENS names need to be resolved when using Metamask
+const lenderAddress = require('../../contracts/addresses/ensMainnet.json').LENDER; //TODO: ENS names need to be resolved when using Metamask
 
 module.exports = class Lender {
     constructor(provider, web3) {
@@ -23,9 +23,10 @@ module.exports = class Lender {
     // Basic sending of Ether to the fallback function of the Lender contract
     // !!! Initiates the sending of Ether !!!
     async useLenderFallback(amount) {
+        resolvedEnsAddress = await this.currentProvider.resolveName(lenderAddress)
         let valueToInvest = ethers.utils.parseEther(amount)
         let txInfo = {
-            to: lenderAddress,
+            to: resolvedEnsAddress,
             value: valueToInvest,
             gasLimit: 5000000,
         }


### PR DESCRIPTION
- ENS addresses must be resolved for use with Metamask (not needed with vanilla ethers.js)