### PR TITLE
Use LetsInvest functions instead of relying on fallback

### DIFF
--- a/examples/basicUsage.js
+++ b/examples/basicUsage.js
@@ -10,7 +10,7 @@ const DefiZap = require('../src/DefiZap');
     // Invest 0.01 eth into the Lender contract (90% cDai, 10% dLETH2x)
     // Optional argument gasPrice is a string
 
-    // const lender = await lenderZap.useFallback('0.01', gasPrice.fast)  
+    // const lender = await lenderZap.invest('0.01', gasPrice.fast)  
 
     const ethMaxZap = defiZap.zap('EthMaximalist')
     const ethMaxAddress = await ethMaxZap.address
@@ -19,7 +19,7 @@ const DefiZap = require('../src/DefiZap');
     // Invest 0.01 eth into the Eth Maximalist contract (50% dLETH2x, 50% dsWBTC).
     // Omitting optional gas price argument uses median gas price from last blocks
     
-    // const ethMax = await ethMaxZap.useFallback('0.01') 
+    // const ethMax = await ethMaxZap.invest('0.01') 
 
     const moderateBullZap = defiZap.zap('ModerateBull')
     const moderateBullAddress = await moderateBullZap.address
@@ -41,6 +41,6 @@ const DefiZap = require('../src/DefiZap');
         moderateBullAddress, moderateBullBalance,
         superSaverAddress, superSaverBalance,
         doubleBullAddress, doubleBullBalance,
-        gasPrice.fast, gasPrice.average, gasPrice.slow 
+        'Gas Prices:', gasPrice.fast, gasPrice.average, gasPrice.slow 
         )
 })()

--- a/src/zaps/GenericZap.js
+++ b/src/zaps/GenericZap.js
@@ -16,7 +16,7 @@ module.exports = class GenericZap {
 
     // Returns Lender contract balance as a Big Number.
     async getBalance() {
-        let balance =  await this.contract.balance()
+        let balance = await this.contract.balance()
         return ethers.utils.formatEther(balance.toString())
     }
 
@@ -25,13 +25,46 @@ module.exports = class GenericZap {
         return await this.contract.owner()
     }
 
-    // Basic sending of Ether to the fallback function of the Lender contract
+    // Sending Ether to the investment function of the contract
+    // !!! Initiates the sending of Ether !!!
+    async invest(amount, price) {
+        this.contractWithSigner = this.contract.connect(this.signer)
+        let valueToInvest = ethers.utils.parseEther(amount)
+        let gasPriceHex
+        if (price) gasPriceHex = ethers.utils.parseUnits(price, 'gwei')
+        else gasPriceHex = await this.currentProvider.getGasPrice()
+        let txInfo = {
+            value: valueToInvest,
+            gasLimit: 5000000,
+            gasPrice: gasPriceHex
+        }
+        let tx
+        switch (this.name) {
+            case 'Lender':
+                tx = await this.contractWithSigner.SafeNotSorryZapInvestment(txInfo)
+                break
+            case 'EthMaximalist':
+                tx = await this.contractWithSigner.ETHMaximalistZAP(txInfo)
+                break
+            case 'ModerateBull':
+                txInfo.gasPrice = ethers.utils.parseUnits('1.0', 'gwei')
+                tx = await this.contractWithSigner.LetsInvest(txInfo)
+                break
+            default:
+                tx = await this.contractWithSigner.LetsInvest(txInfo)
+                break
+        }
+        return tx
+
+    }
+
+    // Basic sending of Ether to the fallback function of the contract
     // !!! Initiates the sending of Ether !!!
     async useFallback(amount, price) {
         const resolvedEnsAddress = await this.currentProvider.resolveName(this.address)
         let valueToInvest = ethers.utils.parseEther(amount)
         let gasPriceHex
-        if(price) gasPriceHex = ethers.utils.parseUnits(price, 'gwei')
+        if (price) gasPriceHex = ethers.utils.parseUnits(price, 'gwei')
         else gasPriceHex = await this.currentProvider.getGasPrice()
         let txInfo = {
             to: resolvedEnsAddress,


### PR DESCRIPTION
- Zaps relying on Synthetix contracts will always use 1 gwei for the gas price to avoid 'Gas price above limit' errors.